### PR TITLE
default to private repo, inclusion of a flag for public repos

### DIFF
--- a/.my_commands.sh
+++ b/.my_commands.sh
@@ -2,7 +2,13 @@
 
 function create() {
      cd
-     python3 /users/gabrielefarei/documents/development/new_repo_automation/create.py $1
+     if (($# > 1 )); 
+     then
+        python3 /users/gabrielefarei/documents/development/new_repo_automation/create.py $1 $2
+     else 
+        python3 /users/gabrielefarei/documents/development/new_repo_automation/create.py $1 
+     fi 
+     
      cd /users/gabrielefarei/documents/development/$1
      git init
      git remote add origin git@github.com:jayfarei/$1.git

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ touch ~/.bashrc
 touch ~/.bash_profile
 ```
 
-Edit both file (`atom ~/.bashrc`) and include the link to the custom alias provided by this repository
+Edit both file (`code ~/.bashrc`) and include the link to the custom alias provided by this repository
 
-Note: if you use zsh - do the same for `atom ~/.zshrc`
+Note: if you use zsh - do the same for `code ~/.zshrc`
 
 
 ```
@@ -123,9 +123,9 @@ cd ~/documents/development/new_repo_automation
 touch .my_commands.sh
 touch create.py
 ```
-Open folder in Atom
+Open folder in Code
 ```
-atom .
+code .
 ```
 
 Create a bashrc file to source your aliases
@@ -136,7 +136,7 @@ touch ~/.bashrc
 Link the aliases in the bashrc files
 
 ```
-atom ~/.bashrc
+code ~/.bashrc
 ```
 
 Reference the alias we'll be working on so that it'll be loaded at login

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 ## Automating the creation of a Github repository from one terminal command
 
+From anywhere from your terminal use this CLI: 
+```
+create <project_name> 
+```
+add the flag  `-p` the make the repo public.
+
+And end up with a project folder set up, in sync with github & with VS Code open on the README.
+
+
+----
+
 
 #### Requirement this is solving for:
 
 > Create a terminal command that automates the steps I take when creating a new project
-
-Command line instruction:
-
-```
-create <project_name>
-```
-
-The automation should perform the following actions:
-
 
 **Set up local folder structure**
 
@@ -25,19 +27,20 @@ The automation should perform the following actions:
 4. Create git `git init`
 5. Navigate to github.com -> copy the remote of the new repository
 6. Add the remote to the local folder `git remote add origin https://github.com/JayFarei/<newproject>.git`
-7. Create base readme with `touch README.md`
-8. Git add `git add .`
-9. Git commit `git commit -m 'initial commit'`
-10. Git push `git push --set-upstream origin master`
+7. Decide whether to set it as `public` or `private`
+8. Create base readme with `touch README.md`
+9. Git add `git add .`
+10. Git commit `git commit -m 'initial commit'`
+11. Git push `git push --set-upstream origin master`
 
 **Open project with my editor of choice**
 
-11. Open the project folder in atom with `atom .`
+11. Open the project folder in atom with `code .`
 
 
 ## How to use it
 
-1. Get the repository
+1. Download the repo
 
 ```
 git clone "https://github.com/JayFarei/new_repo_automation.git"
@@ -97,70 +100,25 @@ Note: every time you do a change you'll have to source it again.
 
 4. Enter your access token from Github
 
-* Obtain your Access token from Github
+   * Obtain your Access token from Github
 
-* Replace `accessToken` in `/users/<username>/documents/development/new_repo_automation/create.py`
+   * Replace `accessToken` in `/users/<username>/documents/development/new_repo_automation/create.py`
 
-* Replace path to match your set up in `create.py` or `.my_commands.sh`
+   * Replace path to match your set up in `create.py` or `.my_commands.sh`
 
 5. Run the command line instruction
 
 Open the terminal - a run the following instruction
 
 ```
-create <New Project>
+create <New Project> [-p]
 ```
 
 
 
 ## Notes in making it:
 
-Navigate to your project folder and create the key files
-```
-cd ~/documents/development/new_repo_automation
-```
-```
-touch .my_commands.sh
-touch create.py
-```
-Open folder in Code
-```
-code .
-```
-
-Create a bashrc file to source your aliases
-```
-cd
-touch ~/.bashrc
-```
-Link the aliases in the bashrc files
-
-```
-code ~/.bashrc
-```
-
-Reference the alias we'll be working on so that it'll be loaded at login
-
-```
-## Github repository automation
-source ~/documents/development/new_repo_automation/my_commands.sh
-```
-
 Note: whenever you make a change to the `.my_commands.sh` you'll have run this instruction `source ~/documents/development/new_repo_automation/.my_commands.sh` are the alias seems to be loaded in memory.
-
-
-Install dependencies
-
-```
-sudo easy_install pip
-```
-
-then install the requirements included in the requirements.txt file in the repository
-
-```
-sudo pip install -r ~/documents/development/new_repo_automation/requirements.txt
-```
-
 
 **Python script**
 
@@ -175,7 +133,12 @@ You will need the following import:
 `from github import Github`
 > Following this https://github.com/PyGithub/PyGithub / this allow you to authenticate to github APIs from a python script
 
-Note: I used mkdir as the tree already exists.
+`import argparse`
+> Useful argument parsing python library https://docs.python.org/2/howto/argparse.html
+
+
+Regarding the script:
+Note: I used mkdir as the tree already exists in my case
 
 Alternatively, makedirs is a recursive directory creation function. Like mkdir(), but makes all intermediate-level directories needed to contain the leaf directory. In our case it has to follow a cd command otherwise it'll generate all directories wherever we are based
 
@@ -188,6 +151,6 @@ filename = sys.argv[1]
 
 **Bash script**
 
-The script is self explanatory - if you were to do all the instructions individually on your terminal - you'll end up with this set of instructions.
+The script is self explanatory - if you were to do all the instructions individually on your terminal - you'll end up with this set of instructions. I set an if statement to pass on to the python script only the arguments provided. Note: this is not robust to errors in specifying the inputs.
 
 Worth noticing that you will have to use the entire path vs a shortened version (using ~) - I had some issues in my tests with that.

--- a/create.py
+++ b/create.py
@@ -16,6 +16,18 @@ path = "/users/gabrielefarei/documents/development/"
 # Obtaining project folder name from CML
 folderName = str(sys.argv[1])
 
+# CLI has to be provided as: python create.py arg1 arg2 arg3
+
+# len(create.py) = ['create.py', 'arg1', 'arg2', 'arg3']
+
+if len(sys.argv) > 2:
+    # Private boolean
+    privateValue = sys.argv[2]
+
+    # Description
+    description = str(sys.argv[3])
+
+
 # New folder structure
 newpath = path + folderName
 
@@ -27,7 +39,9 @@ user = g.get_user()
 os.mkdir(newpath)
 
 
-
 # Creating github repository
-repo = user.create_repo(folderName)
+repo = user.create_repo(
+    folderName,
+    description=description, 
+    private=privateValue),
 print("Succesfully created repository {}".format(folderName))

--- a/create.py
+++ b/create.py
@@ -1,8 +1,28 @@
 from github import Github
 import sys
 import os
+import argparse
 
-# You need to retrieve your access token from github and store it under credentials.txt in the project folder
+
+## Importing value from the CLI
+
+parser = argparse.ArgumentParser( description='Repository preferences' )
+
+# Defining arugments to parse from the command line
+parser.add_argument('repo_name', action="store", 
+                    help='repository name in one string without spaces')
+
+parser.add_argument('-p', action='store_false', default=True,
+                    dest='public_repo',
+                    help='Set a repository to public')
+
+results = parser.parse_args()
+
+repoName = results.repo_name
+publicRepo = results.public_repo ## 0 when flag, 1 when no flag
+
+
+# Retrieving the access token from github and stored it under credentials.txt in the project folder
 
 # Loading credentials:
 credentials = open ('/users/gabrielefarei/documents/development/new_repo_automation/credentials.txt')
@@ -13,23 +33,8 @@ accessToken = credentials.read().rstrip()
 # Base folder for development projects
 path = "/users/gabrielefarei/documents/development/"
 
-# Obtaining project folder name from CML
-folderName = str(sys.argv[1])
-
-# CLI has to be provided as: python create.py arg1 arg2 arg3
-
-# len(create.py) = ['create.py', 'arg1', 'arg2', 'arg3']
-
-if len(sys.argv) > 2:
-    # Private boolean
-    privateValue = sys.argv[2]
-
-    # Description
-    description = str(sys.argv[3])
-
-
 # New folder structure
-newpath = path + folderName
+newpath = path + repoName
 
 # Accessing github
 g = Github(accessToken)
@@ -41,7 +46,6 @@ os.mkdir(newpath)
 
 # Creating github repository
 repo = user.create_repo(
-    folderName,
-    description=description, 
-    private=privateValue),
-print("Succesfully created repository {}".format(folderName))
+    repoName,
+    private=publicRepo),
+print("Successfully created repository {}".format(repoName))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyGithub
+Argparse


### PR DESCRIPTION
- included Argparse to support multiple arguments and flags in the python script
- amended the API call to add the option to set the repo public but default to private
- amended the script to add the ability to accept one or 2 inputs (name + flag)
- updated readme and requirements.txt